### PR TITLE
Proposed radiation handling

### DIFF
--- a/sources/mods/loria/hud.fnl
+++ b/sources/mods/loria/hud.fnl
@@ -22,8 +22,8 @@
 
 (fn radiation [player]
   (let [meta (player:get_meta)]
-    (.. (string.format "Radiation: %.3f CU/h" (meta:get_float "radiation")) "\n"
-        (string.format "Received dose: %.3f mCU" (* (meta:get_float "received_dose") 1000)))))
+    (.. (string.format "Radiation: %.3f Gy/h" (meta:get_float "radiation")) "\n"
+        (string.format "Received dose: %.3f cGy" (* (meta:get_float "received_dose") 100)))))
 
 (fn copyright [player]
   (join "\n" ""

--- a/sources/mods/loria/init.fnl
+++ b/sources/mods/loria/init.fnl
@@ -104,14 +104,14 @@
     (meta:set_int "oxygen" 0)
     (meta:set_float "radiation" 0)
     (meta:set_float "received_dose" 0)
-    (meta:set_float "dose_damage_limit" 1)
+    (meta:set_float "dose_damage_limit" 4) ; 4 Gy whole-body
     (meta:set_int "space_suit" space-suit-strength))))
 
 (minetest.register_on_respawnplayer (fn [player]
   (let [meta (player:get_meta)]
     (player:set_hp 20)
     (meta:set_float "received_dose" 0)
-    (meta:set_float "dose_damage_limit" 1)
+    (meta:set_float "dose_damage_limit" 4) ; 4 Gy whole-body
     (meta:set_int "space_suit" space-suit-strength))))
 
 (def-globalstep [_]

--- a/sources/mods/radiation/conf.fnl
+++ b/sources/mods/radiation/conf.fnl
@@ -95,7 +95,7 @@
      "loria:plutonium_dioxide"       (α-β-γ 0.0 675e+18 0.0)
      "loria:plutonium_dioxide_brick" (α-β-γ 0.0 635e+18 0.0)
      ;; Americium
-     "loria:americium_trifluoride" (α-β-γ 960e+15 0.0 0.0)
+     "loria:americium_trifluoride" (α-β-γ 960e+15 0.0 960e+15)
      ;; Polluted mercury
      "loria:bucket_polluted_mercury"  (α-β-γ 1e+9 20e+12 25e+12)
      "loria:polluted_mercury_source"  (α-β-γ 2e+9 30e+12 50e+12)

--- a/sources/mods/radiation/conf.fnl
+++ b/sources/mods/radiation/conf.fnl
@@ -12,12 +12,11 @@
       (tset self name val))))
 
 ;; Handlers
-(fn alpha [A dist²] (let [r (- dist²)] (infix A * (math.exp r))))
+(fn alpha [A dist² att] (/ (if (≠ dist² 0) (/ A dist²) A) (math.exp (* att 7e+3))))
 
-(fn beta [A dist²] (if (≠ dist² 0)
-  (infix A * (math.exp (− math.sqrt dist²)) / dist²) A))
+(fn beta [A dist² att] (/ (if (≠ dist² 0) (/ A dist²) A) (math.exp (* att 700))))
 
-(fn rays [A dist²] (if (≠ dist² 0) (/ A dist²) A))
+(fn rays [A dist² att] (/ (if (≠ dist² 0) (/ A dist²) A) (math.exp (* att 180))))
 
 (global ionizing {:alpha alpha :beta beta :gamma rays :X-ray rays})
 
@@ -37,6 +36,29 @@
   (each [_ val (ipairs arr)]
     (tset self val true)))
 
+;; Attenuation relative to water/live tissue
+(global node_attenuation
+  {
+   "loria:ammonium_manganese_pyrophosphate" 3
+   "loria:chromia" 5.22
+   "loria:chromium_fluoride" 3.8
+   "loria:cinnabar" 8.10
+   "loria:cobalt_blue" 3.65
+   "loria:copper_sulfate_pure" 3.60
+   "loria:copper_sulfate" 2.29
+   "loria:copper_sulfate" 2.29
+   "loria:lead_sulfate" 6.29
+   "loria:mercury" 13.5
+   "loria:mercury_oxide" 11.14
+   "loria:nickel_nitrate" 2.05
+   "loria:polluted_mercury_source" 13.5
+   "loria:polluted_mercury_flowing" 7.8
+   "loria:red_mercury_oxide" 11.14
+   "loria:sodium_peroxide" 2.80
+   "loria:sulfur" 2
+  }
+)
+
 ;;; Then set up configuration tables
 (global activity (activity-table))
 
@@ -45,56 +67,64 @@
   (each [name _ (pairs minetest.registered_items)]
     (tset activity name inh))
 
+  ;; Specific activity of each item in Bq
+  ;; We consider that wires are 0.01 m³, ingots are 0.1 m³, pickaxes are 0.2 m³
+  ;; Compounds are scaled by the relative molar mass of radioactive element
   (activity:update
     {;; Thorium
-     "loria:thorium"               (α-β-γ 16.0 5.0 0.0)
-     "loria:thorium_ingot"         (α-β-γ  8.0 3.0 0.0)
-     "electricity:thorium_wire"    (α-β-γ  6.0 2.0 0.0)
-     "loria:thorium_iodide"        (α-β-γ 12.0 4.0 0.0)
-     "loria:thorium_dioxide"       (α-β-γ 14.0 4.5 0.0)
-     "loria:thorium_dioxide_brick" (α-β-γ 10.0 3.0 0.0)
-     "furnace:thorium"             (α-β-γ 13.0 4.0 0.0)
-     "furnace:thorium_active"      (α-β-γ 13.0 4.0 0.0)
+     "loria:thorium"               (α-β-γ 13e+9   0.0 0.0)
+     "loria:thorium_ingot"         (α-β-γ 4.76e+9 0.0 0.0)
+     "electricity:thorium_wire"    (α-β-γ 480e+6  0.0 0.0)
+     "loria:thorium_iodide"        (α-β-γ 1.46e+9 0.0 0.0)
+     "loria:thorium_dioxide"       (α-β-γ 40e+9   0.0 0.0)
+     "loria:thorium_dioxide_brick" (α-β-γ 40e+9   0.0 0.0)
+     "furnace:thorium"             (α-β-γ 13e+9   0.0 0.0)
+     "furnace:thorium_active"      (α-β-γ 13e+9   0.0 0.0)
      ;; Uranium
-     "loria:uranium"                     (α-β-γ 5.0 3.0 0.0)
-     "loria:uranium_ingot"               (α-β-γ 3.0 1.0 0.0)
-     "electricity:uranium_wire"          (α-β-γ 2.0 0.6 0.0)
-     "loria:uranium_tetrachloride"       (α-β-γ 3.0 1.0 0.0)
-     "loria:uranium_tetrachloride_brick" (α-β-γ 2.0 1.0 0.0)
+     "loria:uranium"                     (α-β-γ 250e+9  0.0 0.0)
+     "loria:uranium_ingot"               (α-β-γ 25e+9   0.0 0.0)
+     "electricity:uranium_wire"          (α-β-γ 2.54e+9 0.0 0.0)
+     "loria:uranium_tetrachloride"       (α-β-γ 160e+9  0.0 0.0)
+     "loria:uranium_tetrachloride_brick" (α-β-γ 160e+9  0.0 0.0)
      ;; Plutonium
-     "loria:plutonium"               (α-β-γ 20.0 0.0 0.0)
-     "loria:plutonium_ingot"         (α-β-γ  5.0 0.0 0.0)
-     "electricity:plutonium_wire"    (α-β-γ  7.0 0.0 0.0)
-     "loria:plutonium_trifluoride"   (α-β-γ 20.0 0.0 0.0)
-     "loria:plutonium_tetrafluoride" (α-β-γ 16.0 0.0 0.0)
-     "loria:plutonium_dioxide"       (α-β-γ 40.0 0.0 0.0)
-     "loria:plutonium_dioxide_brick" (α-β-γ 26.0 0.0 0.0)
+     "loria:plutonium"               (α-β-γ 0.0 774e+18 0.0)
+     "loria:plutonium_ingot"         (α-β-γ 0.0 77e+18  0.0)
+     "electricity:plutonium_wire"    (α-β-γ 0.0 7.7e+18 0.0)
+     "loria:plutonium_trifluoride"   (α-β-γ 0.0 615e+18 0.0)
+     "loria:plutonium_tetrafluoride" (α-β-γ 0.0 575e+18 0.0)
+     "loria:plutonium_dioxide"       (α-β-γ 0.0 675e+18 0.0)
+     "loria:plutonium_dioxide_brick" (α-β-γ 0.0 635e+18 0.0)
      ;; Americium
-     "loria:americium_trifluoride" (α-β-γ 5.0 0.0 7.0)
+     "loria:americium_trifluoride" (α-β-γ 960e+15 0.0 0.0)
      ;; Polluted mercury
-     "loria:bucket_polluted_mercury"  (α-β-γ 5.0 2.3 0.0)
-     "loria:polluted_mercury_source"  (α-β-γ 5.0 2.3 0.0)
-     "loria:polluted_mercury_flowing" (α-β-γ 5.0 2.3 0.0)
+     "loria:bucket_polluted_mercury"  (α-β-γ 1e+9 20e+12 25e+12)
+     "loria:polluted_mercury_source"  (α-β-γ 2e+9 30e+12 50e+12)
+     "loria:polluted_mercury_flowing" (α-β-γ 2e+9 30e+12 50e+12)
      ;; Technic
-     "furnace:refiner_active" (α-β-γ 0.0 0.0 0.3)
+     "furnace:refiner_active" (α-β-γ 0.0 0.0 15e+12)
      ;; Organic
-     "loria:periculum"   (α-β-γ 0.0 0.0 0.50)
-     "loria:imitationis" (α-β-γ 0.0 0.0 0.05)
-     "loria:nihil"       (α-β-γ 0.0 0.0 0.01)
-     "loria:lectica"     (α-β-γ 0.0 0.0 0.07)
+     "loria:periculum"   (α-β-γ 0.0 0.0 50e+12)
+     "loria:imitationis" (α-β-γ 0.0 0.0 5e+12)
+     "loria:nihil"       (α-β-γ 0.0 0.0 1e+12)
+     "loria:lectica"     (α-β-γ 0.0 0.0 7e+12)
      ;; Pickaxes
-     "loria:uranium_pickaxe"   (α-β-γ 3.0 2.0 0.0)
-     "loria:thorium_pickaxe"   (α-β-γ 5.0 2.0 0.0)
-     "loria:plutonium_pickaxe" (α-β-γ 8.0 0.0 0.0)
+     "loria:uranium_pickaxe"   (α-β-γ 50e+9 0.0 0.0)
+     "loria:thorium_pickaxe"   (α-β-γ 9.52e+9 0.0 0.0)
+     "loria:plutonium_pickaxe" (α-β-γ 0.0 154e+18 0.0)
      ;; Other
-     "radiation:danger" (α-β-γ 750 350 150)})
+     "radiation:danger" (α-β-γ 7.5e+12 350e+12 7.5e+12)})
 
   (each [name params (pairs ores)]
     (when (∈ :radioactive params)
       (let [A₀ (. activity (cid (.. "loria:" name)))
             A  (α-β-γ (/ A₀.alpha 5) (/ A₀.beta 3) (/ A₀.gamma 2))]
         (each [_ place (ipairs params.wherein)]
-          (tset activity (cid (.. "loria:" name "_" place)) A))))))
+          (tset activity (cid (.. "loria:" name "_" place)) A))))
+    (each [_ place (ipairs params.wherein)]
+        (tset node_attenuation (cid (.. "loria:" name "_" place)) (cid (.. "loria:" place)))
+    )
+  )
+)
 
 (global antiradiation_drugs
   {"loria:manganese_oxide" 0.5})

--- a/sources/mods/radiation/init.fnl
+++ b/sources/mods/radiation/init.fnl
@@ -6,7 +6,7 @@
 (local radiation-vect (vector.new 16 16 16))
 (local radiation-effects-timeout 1)
 
-(local maximum-dose 5)   ; CU
+(local maximum-dose 20)   ; CU
 
 (local height-coeff (/ 5 10000))
 
@@ -176,7 +176,13 @@
      :min-dose  8
      :conflicts ["blindness"]
      :action (fn [player] (tint player {:r 0 :g 0 :b 0 :a 240}))
-     :revert reset-tint}})
+     :revert reset-tint}
+   "weakness"
+    {:prob      0.1
+     :min-dose  3
+     :conflicts []
+     :action (fn [player] (player:set_physics_override {"speed" 0.3}))
+     :revert (fn [player] (player:set_physics_override {"speed" 1}))}})
 
 (fn applied? [meta name]
   (> (meta:get_int name) 0))
@@ -215,7 +221,7 @@
         (do (meta:set_float :dose_damage_limit (+ dose-damage-limit drug-value))
             (drug-stack:set_count (- (drug-stack:get_count) 1))
             (inv:set_stack :antiradiation 1 drug-stack))
-        (player:set_hp (- (player:get_hp) (math.floor dose))))))
+        (player:set_hp (- (player:get_hp) (math.floor (/ dose 4)))))))
 
   ;; Other effects
   (let [meta (player:get_meta)]

--- a/sources/mods/radiation/init.fnl
+++ b/sources/mods/radiation/init.fnl
@@ -84,8 +84,8 @@
             (if (= kind "beta")
               (tset radiation kind
                 (+ (. radiation kind)
-                   (/ (* (. A kind) stack-count) 1000)))
-              (when (= kind "beta")
+                   (/ (* (. A kind) stack-count) 10)))
+              (when (= kind "gamma")
                 (tset radiation kind
                   (+ (. radiation kind)
                      (/ (* (. A kind) stack-count) 50))))
@@ -155,9 +155,9 @@
     (tset radiation :alpha
       (+ radiation.alpha
         (*
-          (* (. (get-activity (wielded:get_name)) :alpha)
+          (/ (. (get-activity (wielded:get_name)) :alpha)
             (wielded:get_count))
-          500)
+          10)
       ))
     (set radiation (add radiation (calculate-inventory-radiation
                                     (player:get_inventory)))))


### PR DESCRIPTION
As stated in #7 and discussed with @forked-from-1kasper, I am contributing some changes to the way radiation is handled. This includes:
* Ray-casting so radiation through walls is handled correctly (slow for polluted mercury oceans, fast elsewhere).
* Updated activity values using the actual experimental activities when possible.
* Different attenuation for each material so walls can screen radiation to a different degree.
* Different ionizing power for each type of radiation.
* Doses in Gy, with an approximate conversion from activities that at least appears reasonable.
* Updated thresholds for each radiation effect, and a weakness effect.

Effects:
* It's easier to find shelter from radiation, as the ground tends to screen all radioactive ores below.
* Plants and uranium are not much more or less dangerous than before this PR.
* Thorium is almost non-radioactive.
* Americium and plutonium are so radioactive that coming anywhere near their ores would yield a lethal dose of radiation _instantly_. To prevent this, I've capped the maximum amount of radiation to 1 kGy/h, but a player would be forced to avoid them anyway. Some mechanism is required to allow crafting with them.