### PR TITLE
Fix ores not emitting radiation and optimize raycast

### DIFF
--- a/sources/mods/radiation/init.fnl
+++ b/sources/mods/radiation/init.fnl
@@ -27,16 +27,19 @@
      (^ (- pos₁.y pos₂.y) 2)
      (^ (- pos₁.z pos₂.z) 2)))
 
+(local max-attenuation 20)
 (fn radiation-summary [A source pos area data]
   (let [dist² (hypot-sqr source pos)]
     (var attenuation 0)
 
     (if (> dist² 0.5)
-      (each [thing (Raycast source pos false true)]
+      (each [thing (Raycast source pos false true) &until (> attenuation max-attenuation)]
         (when (∧ (= thing.type "node"))
           (let [cid (. data (area:indexp thing.under))
                 att (or (. node_attenuation cid) 1.2e-3)]
-            (set+ attenuation (* att 0.5)))))
+            (set+ attenuation (* (if (> (hypot-sqr source thing.under) 0.5)
+                att (/ att 1000))
+            0.5)))))
       (set attenuation 0.01))
 
     (var res {})


### PR DESCRIPTION
Now radiation is only emitted at the surface of a node, so its attenuation is set to 1000 times lower.

This PR also contains an optimization to limit raycast iteration, which speeds up radiation handling several times on my machine.