### PR TITLE
Tweak values

### DIFF
--- a/sources/mods/radiation/conf.fnl
+++ b/sources/mods/radiation/conf.fnl
@@ -93,9 +93,9 @@
      ;; Americium
      "loria:americium_trifluoride"       (α-β-γ 960e+15 0.0     960e+15)
      ;; Polluted mercury
-     "loria:bucket_polluted_mercury"     (α-β-γ 1e+9    20e+12  25e+12)
-     "loria:polluted_mercury_source"     (α-β-γ 2e+9    30e+12  50e+12)
-     "loria:polluted_mercury_flowing"    (α-β-γ 2e+9    30e+12  50e+12)
+     "loria:bucket_polluted_mercury"     (α-β-γ 1e+9    20e+9  12e+9)
+     "loria:polluted_mercury_source"     (α-β-γ 2e+9    30e+9  25e+9)
+     "loria:polluted_mercury_flowing"    (α-β-γ 2e+9    30e+9  25e+9)
      ;; Technic
      "furnace:refiner_active"            (α-β-γ 0.0     0.0     15e+12)
      ;; Organic

--- a/sources/mods/radiation/init.fnl
+++ b/sources/mods/radiation/init.fnl
@@ -8,7 +8,7 @@
 
 (local maximum-dose 20) ; Gy
 
-(local height-coeff (/ 2e+15 10000))
+(local height-coeff (/ 0.2e+15 10000))
 
 (fn cosmic-rays [height]
   (var res (null))

--- a/sources/mods/radiation/init.fnl
+++ b/sources/mods/radiation/init.fnl
@@ -36,7 +36,7 @@
         (let [cid (. data (area:indexp thing.under))
               att (or (. node_attenuation cid) 1.2e-3)]
           (set+ attenuation (* (if (> (hypot-sqr source thing.under) 0.5)
-              att (/ att 1000))
+              att (/ att 10000))
           0.5)))))
     (var res {})
     (each [kind handler (pairs ionizing)]

--- a/sources/mods/radiation/init.fnl
+++ b/sources/mods/radiation/init.fnl
@@ -8,7 +8,7 @@
 
 (local maximum-dose 20) ; Gy
 
-(local height-coeff (/ 5 10000))
+(local height-coeff (/ 2e+15 10000))
 
 (fn cosmic-rays [height]
   (var res (null))
@@ -27,7 +27,7 @@
      (^ (- pos₁.y pos₂.y) 2)
      (^ (- pos₁.z pos₂.z) 2)))
 
-(local max-attenuation 20)
+(local max-attenuation 10)
 (fn radiation-summary [A source pos area data]
   (let [dist² (hypot-sqr source pos)]
     (var attenuation 0)
@@ -38,7 +38,7 @@
           (let [cid (. data (area:indexp thing.under))
                 att (or (. node_attenuation cid) 1.2e-3)]
             (set+ attenuation (* (if (> (hypot-sqr source thing.under) 0.5)
-                att (/ att 1000))
+                att (/ att 10000))
             0.5)))))
       (set attenuation 0.01))
 

--- a/sources/mods/radiation/init.fnl
+++ b/sources/mods/radiation/init.fnl
@@ -31,17 +31,13 @@
 (fn radiation-summary [A source pos area data]
   (let [dist² (hypot-sqr source pos)]
     (var attenuation 0)
-
-    (if (> dist² 0.5)
-      (each [thing (Raycast source pos false true) &until (> attenuation max-attenuation)]
-        (when (∧ (= thing.type "node"))
-          (let [cid (. data (area:indexp thing.under))
-                att (or (. node_attenuation cid) 1.2e-3)]
-            (set+ attenuation (* (if (> (hypot-sqr source thing.under) 0.5)
-                att (/ att 10000))
-            0.5)))))
-      (set attenuation 0.01))
-
+    (each [thing (Raycast source pos false true) &until (> attenuation max-attenuation)]
+      (when (∧ (= thing.type "node"))
+        (let [cid (. data (area:indexp thing.under))
+              att (or (. node_attenuation cid) 1.2e-3)]
+          (set+ attenuation (* (if (> (hypot-sqr source thing.under) 0.5)
+              att (/ att 1000))
+          0.5)))))
     (var res {})
     (each [kind handler (pairs ionizing)]
       (tset res kind (handler (. A kind) dist² attenuation)))


### PR DESCRIPTION
This PR includes:
* Changing `max-attenuation` to 10 for speed. Maybe an even lower value would work.
* Setting up cosmic rays so they give a sizeable increase in radiation.
* Removing liquid correction.
* Increasing surface correction so uranium is more radioactive.
* Making polluted mercury less radioactive to compensate the other changes.